### PR TITLE
Fix Python dependency + style updates

### DIFF
--- a/macvim.rb
+++ b/macvim.rb
@@ -1,6 +1,7 @@
 require 'formula'
 
 class Macvim < Formula
+  desc 'GUI for vim, made for OS X'
   homepage 'https://github.com/macvim-dev/macvim'
   head 'https://github.com/macvim-dev/macvim.git'
 
@@ -56,5 +57,14 @@ class Macvim < Formula
     inreplace mvim do |s|
       s.gsub! /^# (VIM_APP_DIR=).*/, "\\1\"#{prefix}\""
     end
+  end
+
+  test do
+    (testpath/'a').write 'hai'
+    (testpath/'b').write 'bai'
+    system bin/'vimdiff', 'a', 'b',
+           '-c', 'FormatCommand diffformat',
+           '-c', 'w! diff.html', '-c', 'qa!'
+    File.exist? 'diff.html'
   end
 end

--- a/macvim.rb
+++ b/macvim.rb
@@ -8,7 +8,7 @@ class Macvim < Formula
 
   depends_on 'gettext' => :build
   depends_on 'lua' => :build
-  depends_on 'python3' => :build
+  depends_on :python3 => :build
 
   def install
     perl_version = '5.16'


### PR DESCRIPTION
The important change is the first commit, changing `depends_on "python3"` to `depends_on :python3`; the latter allows MacVim to be built against non-Homebrewed Pythons (see https://github.com/Homebrew/homebrew/issues/50206#issuecomment-198947852).

The other two commits update the formula to use the style enforced in core, add a description, and a basic test.
